### PR TITLE
Allow (and Demo) usage via a script tag, as well as webpack/module export

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ This can be used on a page which has the following placeholder:
 ```
 The usage of the the library can be found in the [demo](demo/) files.
 
+In particular, note that we bundle a large collection of SVG images, which you
+need to make available somehow and then configure the library to use through the
+`imagesPath` variable.
+
 ### Zoom
 
 The functionality has been included for two zoom buttons. These must be added to the page, along with the placeholder, with the correct IDs, for example:

--- a/demo/index.js
+++ b/demo/index.js
@@ -28,7 +28,7 @@ const getJSON = () => {
 const visualiseData = () => {
   clearDrawing();
   const data = JSON.parse(document.getElementById('result').value);
-  draw(data, document.getElementById('svg-holder'));
+  draw(data, document.getElementById('svg-holder'), '/images');
 };
 
 window.onload = () => {

--- a/demo/index.js
+++ b/demo/index.js
@@ -2,8 +2,12 @@ import executeDraw from '../src/index';
 import { clearSVG } from '../src/utils/svgTools';
 import './demo.css';
 
+const clearDrawing = () => {
+  clearSVG(document.getElementById('svg-holder'));
+};
+
 const getJSON = () => {
-  clearSVG();
+  clearDrawing();
   var files = document.getElementById('selectFiles').files;
   if (files.length <= 0) {
     return false;
@@ -22,13 +26,13 @@ const getJSON = () => {
 };
 
 const visualiseData = () => {
-  clearSVG();
+  clearDrawing();
   const data = JSON.parse(document.getElementById('result').value);
-  executeDraw(data);
+  executeDraw(data, document.getElementById('svg-holder'));
 };
 
 window.onload = () => {
-  document.getElementById('svg-clear').addEventListener('click', clearSVG, true);
+  document.getElementById('svg-clear').addEventListener('click', clearDrawing, true);
   document.getElementById('import').addEventListener('click', getJSON, true);
   document.getElementById('draw-vis').addEventListener('click', visualiseData, true);
 };

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,4 +1,4 @@
-import executeDraw from '../src/index';
+import { draw } from '../src/index';
 import { clearSVG } from '../src/utils/svgTools';
 import './demo.css';
 
@@ -28,7 +28,7 @@ const getJSON = () => {
 const visualiseData = () => {
   clearDrawing();
   const data = JSON.parse(document.getElementById('result').value);
-  executeDraw(data, document.getElementById('svg-holder'));
+  draw(data, document.getElementById('svg-holder'));
 };
 
 window.onload = () => {

--- a/demo/script-tag.html
+++ b/demo/script-tag.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>BODS Data Visualisation Demo</title>
+    <link type="text/css" rel="stylesheet" href="demo.css"/>
+  </head>
+  <body>
+    <div class="main-article">
+      <h1>BODS Data Visualisation Demo</h1>
+      <div class="file-input">
+        <input type="file" id="selectFiles" value="Import" /><br />
+        <button id="import">Import</button>
+        <textarea id="result">[]</textarea>
+      </div>
+      <div class="drawing-controls">
+        <button class="drawing-control" id="draw-vis">Draw</button>
+        <button class="drawing-control" id="svg-clear">Clear</button>
+      </div>
+      <div id="svg-holder">
+        <svg id="bods-svg"></svg>
+        <button id="zoom_in">+</button>
+        <button id="zoom_out">-</button>
+      </div>
+    </div>
+  </body>
+  <script src="bods-dagre.js"></script>
+  <script src="demo.js"></script>
+</html>

--- a/demo/script-tag.js
+++ b/demo/script-tag.js
@@ -1,0 +1,37 @@
+var clearDrawing = function() {
+  const svg = document.getElementById('bods-svg');
+  if(svg) {
+    svg.remove();
+  }
+};
+
+var getJSON = function() {
+  clearDrawing();
+  var files = document.getElementById('selectFiles').files;
+  if (files.length <= 0) {
+    return false;
+  }
+
+  var fr = new FileReader();
+
+  fr.onload = function (e) {
+    var result = JSON.parse(e.target.result);
+    var formatted = JSON.stringify(result, null, 2);
+    document.getElementById('result').value = formatted;
+    visualiseData();
+  };
+
+  fr.readAsText(files.item(0));
+};
+
+var visualiseData = function() {
+  clearDrawing();
+  var data = JSON.parse(document.getElementById('result').value);
+  BODSDagre.draw(data, document.getElementById('svg-holder'), '/images');
+};
+
+window.onload = function() {
+  document.getElementById('svg-clear').addEventListener('click', clearDrawing, true);
+  document.getElementById('import').addEventListener('click', getJSON, true);
+  document.getElementById('draw-vis').addEventListener('click', visualiseData, true);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1178,6 +1178,32 @@
         }
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "@npmcli/move-file": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
@@ -2738,6 +2764,111 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-webpack-plugin": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.1.0.tgz",
+      "integrity": "sha512-aWjIuLt1OVQxaDVffnt3bnGmLA8zGgAJaFwPA+a+QYVPh1vhIKjVfh3SbOFLV0kRPvGBITbw17n5CsmiBS4LQQ==",
+      "dev": true,
+      "requires": {
+        "cacache": "^15.0.5",
+        "fast-glob": "^3.2.4",
+        "find-cache-dir": "^3.3.1",
+        "glob-parent": "^5.1.1",
+        "globby": "^11.0.1",
+        "loader-utils": "^2.0.0",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^3.0.2",
+        "schema-utils": "^2.7.1",
+        "serialize-javascript": "^4.0.0",
+        "webpack-sources": "^1.4.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "core-js-compat": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
@@ -3361,6 +3492,15 @@
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
           "dev": true
         }
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
       }
     },
     "dns-equal": {
@@ -4055,6 +4195,65 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4066,6 +4265,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -5610,6 +5818,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -6362,6 +6576,12 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -6374,6 +6594,12 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -6986,6 +7212,12 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -7009,6 +7241,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "run-queue": {
@@ -7279,6 +7517,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/preset-env": "^7.11.0",
     "babel-loader": "^8.1.0",
     "clean-webpack-plugin": "^3.0.0",
+    "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^3.5.3",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",

--- a/publish-demo.sh
+++ b/publish-demo.sh
@@ -1,3 +1,4 @@
+set -euf -o pipefail
 rm -rf demo-build
 git worktree add demo-build gh-pages
 npm run demo

--- a/publish-demo.sh
+++ b/publish-demo.sh
@@ -3,7 +3,7 @@ git worktree add demo-build gh-pages
 npm run demo
 cd demo-build
 git add --all
-git commit -m "New demo build"
+git commit -m "New demo build [ci skip]"
 git push origin gh-pages
 cd ..
 git worktree remove demo-build

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { getPersonNodes, getEntityNodes, setUnknownNode } from './nodes/nodes';
 import { getOwnershipEdges } from './edges/edges';
 import './style.css';
 
-const executeDrawing = (data, container) => {
+const draw = (data, container) => {
   const g = new dagreD3.graphlib.Graph({});
   g.setGraph({
     rankdir: 'LR',
@@ -242,4 +242,4 @@ const executeDrawing = (data, container) => {
   svg.attr('height', g.graph().height * initialScale + 40);
 };
 
-export default executeDrawing;
+export { draw };

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,12 @@ import dagreD3 from 'dagre-d3';
 import Bezier from 'bezier-js';
 import bezierBuilder from './utils/bezierBuilder';
 import sanitise from './utils/sanitiser';
+import { clearSVG } from './utils/svgTools';
 import { getPersonNodes, getEntityNodes, setUnknownNode } from './nodes/nodes';
 import { getOwnershipEdges } from './edges/edges';
 import './style.css';
 
-const executeDrawing = (data) => {
+const executeDrawing = (data, container) => {
   const g = new dagreD3.graphlib.Graph({});
   g.setGraph({
     rankdir: 'LR',
@@ -42,8 +43,9 @@ const executeDrawing = (data) => {
     })
   );
 
-  const svg = d3.select('svg'),
-    inner = svg.append('g');
+  clearSVG(container);
+  const svg = d3.select('svg');
+  const inner = svg.append('g');
 
   // Create the renderer
   const render = new dagreD3.render();

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { getPersonNodes, getEntityNodes, setUnknownNode } from './nodes/nodes';
 import { getOwnershipEdges } from './edges/edges';
 import './style.css';
 
-const draw = (data, container) => {
+const draw = (data, container, imagesPath) => {
   const g = new dagreD3.graphlib.Graph({});
   g.setGraph({
     rankdir: 'LR',
@@ -17,8 +17,8 @@ const draw = (data, container) => {
     ranksep: 200,
   });
 
-  const personNodes = getPersonNodes(data);
-  const entityNodes = getEntityNodes(data);
+  const personNodes = getPersonNodes(data, imagesPath);
+  const entityNodes = getEntityNodes(data, imagesPath);
   const ownershipEdges = getOwnershipEdges(data);
 
   const edges = [...ownershipEdges];

--- a/src/nodes/nodeHTMLLabel.js
+++ b/src/nodes/nodeHTMLLabel.js
@@ -1,7 +1,6 @@
 import sanitise from '../utils/sanitiser';
-const images = require.context('../images', true);
 
-const generateNodeLabel = (nodeType, nodeText, countryCode) => {
+const generateNodeLabel = (nodeType, nodeText, countryCode, imagesPath) => {
   return `
     <div class='centred-label'>
       <div class="image-holder">
@@ -9,14 +8,13 @@ const generateNodeLabel = (nodeType, nodeText, countryCode) => {
       </div>
       <div class="node-glyph top-right">
         ${
-          countryCode
-            ? `<img class="node-flag" src="${images('./flags/' + sanitise(countryCode) + '.svg', true)}"/>`
-            : ''
+          countryCode ? `<img class="node-flag" src="${imagesPath}/flags/${sanitise(countryCode)}.svg"/>` : ''
         }
         </div>
         <div class="node-glyph bottom-left"></div>
         <div class="node-glyph bottom-right"></div>
-        <img class="node-image" src="${images('./' + sanitise(nodeType) + '.svg', true)}"></img><br>
+        <img class="node-image" src="${imagesPath}/${sanitise(nodeType)}.svg"/>
+        <br>
       </div>
       <div class="node-label wrap-text">
         ${sanitise(nodeText)}

--- a/src/nodes/nodes.js
+++ b/src/nodes/nodes.js
@@ -27,7 +27,7 @@ const personName = (name) => {
   return nameParts.join(' ');
 };
 
-export const getPersonNodes = (bodsData) => {
+export const getPersonNodes = (bodsData, imagesPath) => {
   return bodsData
     .filter((statement) => statement.statementType === 'personStatement')
     .map((statement) => {
@@ -36,7 +36,7 @@ export const getPersonNodes = (bodsData) => {
       const countryCode = nationalities ? nationalities[0].code : null;
       return {
         id: statementID,
-        label: generateNodeLabel(nodeType, personName(names[0]), countryCode),
+        label: generateNodeLabel(nodeType, personName(names[0]), countryCode, imagesPath),
         labelType: 'html',
         class: nodeType,
         config: nodeConfig,
@@ -44,7 +44,7 @@ export const getPersonNodes = (bodsData) => {
     });
 };
 
-export const getEntityNodes = (bodsData) => {
+export const getEntityNodes = (bodsData, imagesPath) => {
   return bodsData
     .filter((statement) => statement.statementType === 'entityStatement')
     .map((statement) => {
@@ -52,7 +52,7 @@ export const getEntityNodes = (bodsData) => {
       const countryCode = incorporatedInJurisdiction ? incorporatedInJurisdiction.code : null;
       return {
         id: statementID,
-        label: generateNodeLabel('entity', name, countryCode),
+        label: generateNodeLabel('entity', name, countryCode, imagesPath),
         labelType: 'html',
         class: 'entity',
         config: nodeConfig,

--- a/src/utils/svgTools.js
+++ b/src/utils/svgTools.js
@@ -1,8 +1,8 @@
 import * as d3 from 'd3';
 
-const clearSVG = async () => {
-  d3.select('#svg-holder').select('#bods-svg').remove();
-  d3.select('#svg-holder').append('svg').attr('id', 'bods-svg');
+const clearSVG = async (container) => {
+  d3.select(container).select('#bods-svg').remove();
+  d3.select(container).append('svg').attr('id', 'bods-svg');
 };
 
 export { clearSVG };

--- a/webpack.demo.config.js
+++ b/webpack.demo.config.js
@@ -5,11 +5,16 @@ const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   mode: 'production',
-  entry: './demo/index.js',
-  output: {
-    filename: 'main.js',
-    path: path.resolve(__dirname, 'demo-build'),
+  entry: {
+    main: './demo/index.js',
+    'bods-dagre': './src/index.js',
   },
+  output: {
+    filename: '[name].js',
+    path: path.resolve(__dirname, 'demo-build'),
+    library: 'BODSDagre',
+  },
+  devtool: 'source-map',
   module: {
     rules: [
       {
@@ -25,16 +30,26 @@ module.exports = {
   },
   plugins: [
     // new CleanWebpackPlugin(),
-    new HtmlWebpackPlugin({ inject: true, template: './demo/index.html' }),
+    new HtmlWebpackPlugin({
+      inject: true,
+      template: './demo/index.html',
+      excludeChunks: ['bods-dagre'],
+    }),
     new TerserPlugin({
       // Use multi-process parallel running to improve the build speed
       // Default number of concurrent runs: os.cpus().length - 1
       parallel: true,
       // Enable file caching
       cache: true,
+      sourceMap: true,
     }),
     new CopyPlugin({
-      patterns: [{ from: 'src/images', to: 'images' }],
+      patterns: [
+        { from: 'src/images', to: 'images' },
+        { from: 'demo/script-tag.html', to: 'script-tag.html' },
+        { from: 'demo/demo.css', to: 'demo.css' },
+        { from: 'demo/script-tag.js', to: 'demo.js' },
+      ],
     }),
   ],
 };

--- a/webpack.demo.config.js
+++ b/webpack.demo.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   mode: 'production',
@@ -15,18 +15,6 @@ module.exports = {
       {
         test: /\.css$/,
         use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              esModule: false,
-              name: 'images/[name].[ext]',
-            },
-          },
-        ],
       },
       {
         test: /\.js$/,
@@ -44,6 +32,9 @@ module.exports = {
       parallel: true,
       // Enable file caching
       cache: true,
+    }),
+    new CopyPlugin({
+      patterns: [{ from: 'src/images', to: 'images' }],
     }),
   ],
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   mode: 'development',
@@ -24,18 +24,6 @@ module.exports = {
         use: ['style-loader', 'css-loader'],
       },
       {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              esModule: false,
-              name: 'images/[name].[ext]',
-            },
-          },
-        ],
-      },
-      {
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
@@ -52,6 +40,9 @@ module.exports = {
       // Enable file caching
       cache: true,
       sourceMap: true,
+    }),
+    new CopyPlugin({
+      patterns: [{ from: 'src/images', to: 'images' }],
     }),
   ],
 };

--- a/webpack.library.config.js
+++ b/webpack.library.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   mode: 'production',
@@ -14,18 +15,6 @@ module.exports = {
       {
         test: /\.css$/,
         use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              esModule: false,
-              name: 'images/[name].[ext]',
-            },
-          },
-        ],
       },
       {
         test: /\.js$/,
@@ -42,6 +31,9 @@ module.exports = {
       parallel: true,
       // Enable file caching
       cache: true,
+    }),
+    new CopyPlugin({
+      patterns: [{ from: 'src/images', to: 'images' }],
     }),
   ],
 };

--- a/webpack.library.config.js
+++ b/webpack.library.config.js
@@ -7,9 +7,11 @@ module.exports = {
   mode: 'production',
   entry: './src/index.js',
   output: {
-    filename: 'main.js',
+    filename: 'bods-dagre.js',
     path: path.resolve(__dirname, 'dist'),
+    library: 'BODSDagre',
   },
+  devtool: 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
There were a few related issues to solve here:

- Proper library output from the library config
- Choosing a name!
- Making the runtime path to the images configurable for re-users
- Making the demo builds work in both main ways (sort of) simultaneously.

It took me a lot of Webpack documentation scouring, but I don't think the solution is too bad, barring a couple of places where code/config is duplicated in the demo.