### PR TITLE
Publish on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,65 @@
-# Visualisation Tool
+# BODS-Dagre
 
-**N.B. This tool is still in development**
+BODS-Dagre is a small javascript library for automatic generation of directed
+graphs representing Beneficial Ownership Data for the web. It relies on d3,
+dagre-d3 and bezier-js to do all the heavy lifting.
 
-The Visualisation Tool is a small javascript library for automatic generation of directed graphs representing Beneficial Ownership Data for the web.
+The tool accepts [Beneficial Ownership Data](http://standard.openownership.org/)
+(JSON) as input and outputs SVG content on a webpage which contains the
+appropriate placeholder HTML.
 
-The tool accepts [Beneficial Ownership Data](http://standard.openownership.org/) (JSON) as input and outputs SVG content on a webpage which contains the appropriate placeholder.
+For a hosted version you can use directly, see [our main website's installation](/visualisation/visualisation-tool/)
 
-At present this library does not output pure SVG content and depends on HTML nodes within the graph.
+## Installation & Usage
+
+Through your package manager:
+
+```shell
+$ npm install @openownership/bods-dagre
+```
+
+Or as a script tag:
+
+```html
+<script src="https://unpkg.com/@openownership/bods-dagre/dist/bods-dagre.js"></script>
+```
+
+Then in your application:
+
+```js
+// Your BODS data
+const data = JSON.parse('some JSON string');
+// Where you want the SVG drawn
+const container = document.getElementById('some-id');
+// Where you're serving the bundled images from (see below)
+const imagesPath = '/some/folder';
+
+BODSDagre.draw(data, container, imagesPath);
+```
+
+Full demo applications are hosted from this repo:
+- <a href="https://openownership.github.io/visualisation-tool/">Using webpack</a>
+- <a href="https://openownership.github.io/visualisation-tool/script-tag.html">Using a script tag</a>
+
+### Images
+
+The library includes license-free SVG images for world flags, as well as some
+generic icons from our [Beneficial Ownership Visualisation System](https://openownership.org/visualisation/).
+
+You can find these inside the dist/images folder, but you need to make them
+available at some URL path in your application and tell the library what that
+path is when you call it.
+
+### Zoom
+
+The functionality has been included for two zoom buttons. These must be added to
+the page, along with the placeholder, with the correct IDs for the code to
+pick them up:
+
+```html
+<button id="zoom_in">+</button>
+<button id="zoom_out">-</button>
+```
 
 ## Development
 To build the project for development using the webpack server run:
@@ -16,7 +69,7 @@ npm i
 npm start
 ```
 
-## Demo Page (Production)
+## Demo Page
 To build the demo page, which uses the templates found in `/demo`, run:
 
 ```
@@ -25,18 +78,7 @@ npm run demo
 ```
 This will output the compiled code, including the demo page, to `demo-build`.
 
-To build and push a new version to gh-pages, run:
-```
-rm -rf demo-build
-git worktree add demo-build gh-pages
-npm run demo
-cd demo-build
-git add --all
-git commit -m "New demo build [ci skip]"
-git push origin gh-pages
-cd ..
-git worktree remove demo-build
-```
+To build and push a new version to gh-pages, run `publish-demo.sh`.
 
 ## Libary compilation
 To build the library without the demo page run:
@@ -47,26 +89,8 @@ npm run library
 ```
 This will compile the javascript into `dist/main.js` and will include all of the required SVG files in `/dist/images`
 
-## Inclusion on webpage
+## Publishing
+To publish this to NPM (assuming you're logged in through the cli and have
+permissions on the project):
 
-This can be used on a page which has the following placeholder:
-
-```
-<div id="svg-holder">
-    <svg id="bods-svg"></svg>
-</div>
-```
-The usage of the the library can be found in the [demo](demo/) files.
-
-In particular, note that we bundle a large collection of SVG images, which you
-need to make available somehow and then configure the library to use through the
-`imagesPath` variable.
-
-### Zoom
-
-The functionality has been included for two zoom buttons. These must be added to the page, along with the placeholder, with the correct IDs, for example:
-
-```
-<button id="zoom_in">+</button>
-<button id="zoom_out">-</button>
-```
+`$ npm publish --access public`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@openownership/bods-dagre",
-  "version": "0.1.0",
-  "private": true,
+  "version": "0.1.1",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "bezier-js": "^2.6.1",
     "d3": "^5.15.0",
@@ -11,6 +13,7 @@
     "demo": "webpack --config=webpack.demo.config.js",
     "dev": "webpack --config=webpack.dev.config.js",
     "library": "webpack --config=webpack.library.config.js",
+    "prepublishOnly": "npm run library",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint src",
     "start": "webpack-dev-server --open --config=webpack.dev.config.js"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@openownership/bods-dagre",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "files": [
     "dist"
   ],
+  "main": "BODSDagre",
+  "repository": "github:openownership/visualisation-tool",
   "dependencies": {
     "bezier-js": "^2.6.1",
     "d3": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openownership/bods-dagre",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@openownership/bods-dagre",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "files": [
     "dist"
   ],
-  "main": "BODSDagre",
+  "main": "dist/bods-dagre.js",
   "repository": "github:openownership/visualisation-tool",
+  "license": "Apache License 2.0",
   "dependencies": {
     "bezier-js": "^2.6.1",
     "d3": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bods-dagre",
+  "name": "@openownership/bods-dagre",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openownership/bods-dagre",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "files": [
     "dist"
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const draw = (data, container, imagesPath) => {
   );
 
   clearSVG(container);
-  const svg = d3.select('svg');
+  const svg = d3.select('#bods-svg');
   const inner = svg.append('g');
 
   // Create the renderer


### PR DESCRIPTION
This adds the necessary package.json config to publish the module on NPM.

I've experimentally done so under a new openownership organisation (manually for now). So you can run `npm install @openownership/bods-dagre@0.1.3` and then require/import `bods-dagre`. You can alternatively include a script tag pointing to https://unpkg.com/@openownership/bods-dagre@0.1.3/dist/bods-dagre.js to get a global into your page.

I'll take a brief look at automating this on Monday, as well as documenting a) how to install the package better and b) how/when to build new versions.