### PR TITLE
edges: Ensure minimum thickness is drawn when interest is exactly 0

### DIFF
--- a/src/edges/edges.js
+++ b/src/edges/edges.js
@@ -75,10 +75,10 @@ export const getOwnershipEdges = (bodsData) => {
           id: statementID,
           interests: mappedInterests,
           interestRelationship,
-          controlStroke,
+          controlStroke: controlStroke > 0 ? controlStroke : 1,
           controlText,
           shareText,
-          shareStroke,
+          shareStroke: shareStroke > 0 ? shareStroke : 1,
           source:
             interestedParty.describedByPersonStatement ||
             interestedParty.describedByEntityStatement ||


### PR DESCRIPTION
Pending a question around whether to draw the minimum line thickness or remove the relationship altogether.
#78 