### PR TITLE
unknown: If edge has unknown source create a unique unknown persons node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,20 @@ const draw = (data, container, imagesPath, labelLimit = 8, rankDir = 'LR') => {
   });
 
   // This section maps the incoming BODS data to the structures expected by Dagre
-  const personNodes = getPersonNodes(data, imagesPath);
-  const entityNodes = getEntityNodes(data, imagesPath);
+  const personNodes = getPersonNodes(data);
+  const entityNodes = getEntityNodes(data);
   const ownershipEdges = getOwnershipEdges(data);
 
   const edges = [...ownershipEdges];
 
-  const unknownSubject = edges.filter((edge) => edge.source === 'unknown');
-  const unknownNode = unknownSubject.length > 0 ? setUnknownNode(imagesPath) : [];
-  const nodes = [...personNodes, ...entityNodes, ...unknownNode];
+  const unknownSubjects = edges.filter((edge, index) => {
+    edge.source = edge.source === 'unknown' ? `unknown${index}` : edge.source;
+    return edge.source === `unknown${index}`;
+  });
+  const unknownNodes = unknownSubjects.map((unknownSubject) => {
+    return setUnknownNode(unknownSubject.source);
+  });
+  const nodes = [...personNodes, ...entityNodes, ...getPersonNodes(unknownNodes)];
 
   nodes.forEach((node) => {
     g.setNode(node.id, {

--- a/src/nodes/nodes.js
+++ b/src/nodes/nodes.js
@@ -2,14 +2,14 @@ import generateNodeLabel from './nodeSVGLabel';
 import latest from '../utils/bods';
 import sanitise from '../utils/sanitiser';
 
-const unknownNode = [
-  {
-    statementID: 'unknown',
+const unknownNode = (nodeId) => {
+  return {
+    statementID: nodeId,
     statementType: 'personStatement',
     personType: 'unknownPerson',
     names: [{ fullName: 'Unknown Person(s)' }],
-  },
-];
+  };
+};
 
 const nodeConfig = {
   shape: 'circle',
@@ -122,4 +122,4 @@ export const getEntityNodes = (bodsData) => {
   );
 };
 
-export const setUnknownNode = (imagesPath) => getPersonNodes(unknownNode, imagesPath);
+export const setUnknownNode = (source) => unknownNode(source);


### PR DESCRIPTION
#111 

This filters all of the edges and looks for ones where the source is unknown. In these cases it appends the source with the index value of the filtered array. This is then used to create a unique `unknownPerson` node for each unknown edge source.

It also removes the `imagesPath` parameter from the function calls, which is no longer used (and hasn't been for some time) until later in the index function.   