### PR TITLE
Viewable statement props

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -51,7 +51,7 @@ button {
   overflow: scroll;
 }
 
-#close-tooltip {
+.close-tooltip {
   width: 40px;
 }
 

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -35,6 +35,21 @@ button {
   text-align: center;
 }
 
+#disclosure-widget details {
+  text-align: left;
+  border: 1px solid #000;
+  padding: 10px;
+  margin: 10px 0 10px 0;
+}
+
+.button-container {
+  text-align: right;
+}
+
+#close-tooltip {
+  width: 40px;
+}
+
 #draw-vis {
   width: 100%;
 }

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -40,10 +40,15 @@ button {
   border: 1px solid #000;
   padding: 10px;
   margin: 10px 0 10px 0;
+  overflow: scroll;
 }
 
 .button-container {
   text-align: right;
+}
+
+.tippy-content pre {
+  overflow: scroll;
 }
 
 #close-tooltip {

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,6 +21,7 @@
         <button id="zoom_in">+</button>
         <button id="zoom_out">-</button>
       </div>
+      <div id="disclosure-widget"></div>
       <button id="download-svg">Download SVG</button>
       <button id="download-png">Download PNG</button>
     </div>

--- a/demo/index.js
+++ b/demo/index.js
@@ -39,7 +39,12 @@ const visualiseData = (data) => {
   // Render data as text
   document.getElementById('result').value = data.formatted;
   // Render data as graph
-  draw(data.parsed, document.getElementById('svg-holder'), 'images', 100);
+  draw({
+    data: data.parsed,
+    container: document.getElementById('svg-holder'),
+    imagesPath: 'images',
+    labelLimit: 100,
+  });
 };
 
 window.onload = () => {

--- a/demo/index.js
+++ b/demo/index.js
@@ -44,6 +44,7 @@ const visualiseData = (data) => {
     container: document.getElementById('svg-holder'),
     imagesPath: 'images',
     labelLimit: 100,
+    useTippy: true,
   });
 };
 

--- a/demo/script-tag.html
+++ b/demo/script-tag.html
@@ -22,6 +22,7 @@
         <button id="zoom_in">+</button>
         <button id="zoom_out">-</button>
       </div>
+      <div id="disclosure-widget"></div>
     </div>
   </body>
   <script src="bods-dagre.js"></script>

--- a/demo/script-tag.js
+++ b/demo/script-tag.js
@@ -63,6 +63,7 @@ const visualiseData = (data) => {
     container: document.getElementById('svg-holder'),
     imagesPath: 'images',
     labelLimit: 100,
+    useTippy: true,
   });
 };
 

--- a/demo/script-tag.js
+++ b/demo/script-tag.js
@@ -58,7 +58,12 @@ const visualiseData = (data) => {
   // Render data as text
   document.getElementById('result').value = data.formatted;
   // Render data as graph
-  BODSDagre.draw(data.parsed, document.getElementById('svg-holder'), 'images', 100);
+  BODSDagre.draw({
+    data: data.parsed,
+    container: document.getElementById('svg-holder'),
+    imagesPath: 'images',
+    labelLimit: 100,
+  });
 };
 
 window.onload = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "d3": "^5.15.0",
         "dagre-d3": "^0.6.4",
         "file-saver": "^2.0.5",
-        "flag-icons": "6.1.1"
+        "flag-icons": "6.1.1",
+        "tippy.js": "^6.3.7"
       },
       "devDependencies": {
         "@babel/core": "^7.11.4",
@@ -1663,6 +1664,15 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@types/anymatch": {
       "version": "1.3.1",
@@ -7894,6 +7904,14 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "d3": "^5.15.0",
     "dagre-d3": "^0.6.4",
     "file-saver": "^2.0.5",
-    "flag-icons": "6.1.1"
+    "flag-icons": "6.1.1",
+    "tippy.js": "^6.3.7"
   },
   "scripts": {
     "demo": "webpack --config=webpack.demo.config.js",

--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,12 @@ import {
   setDashedLine,
 } from './render/renderD3';
 import { setupGraph, setEdges, setNodes } from './render/renderGraph';
-import { setupUI } from './render/renderUI';
+import { setupUI, renderProperties } from './render/renderUI';
 
 import './style.css';
 
 // This sets up the basic format of the graph, such as direction, node and rank separation, and default label limits
-const draw = (data, container, imagesPath, labelLimit = 8, rankDir = 'LR') => {
+const draw = ({ data, container, imagesPath, labelLimit = 8, rankDir = 'LR', viewProperties = true }) => {
   // Initialise D3 and graph
   const { svg, inner } = setupD3(container);
   const { g, render } = setupGraph(rankDir);
@@ -44,10 +44,6 @@ const draw = (data, container, imagesPath, labelLimit = 8, rankDir = 'LR') => {
 
   // Create white backgrounds for all of the node labels so that text legible
   setNodeLabelBkg('white');
-
-  nodes.forEach((node) => {
-    console.log(node.description);
-  });
 
   // calculate the new edges using control and ownership values
   // this section could do with a refactor and move more of the logic into edges.js
@@ -122,6 +118,10 @@ const draw = (data, container, imagesPath, labelLimit = 8, rankDir = 'LR') => {
   const { zoom } = setZoomTransform(inner, svg, g);
 
   setupUI(zoom, svg);
+
+  if (viewProperties) {
+    renderProperties(inner, g);
+  }
 };
 
 export { draw };

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,15 @@ import { setupUI, renderProperties } from './render/renderUI';
 import './style.css';
 
 // This sets up the basic format of the graph, such as direction, node and rank separation, and default label limits
-const draw = ({ data, container, imagesPath, labelLimit = 8, rankDir = 'LR', viewProperties = true }) => {
+const draw = ({
+  data,
+  container,
+  imagesPath,
+  labelLimit = 8,
+  rankDir = 'LR',
+  viewProperties = true,
+  useTippy = false,
+}) => {
   // Initialise D3 and graph
   const { svg, inner } = setupD3(container);
   const { g, render } = setupGraph(rankDir);
@@ -120,7 +128,7 @@ const draw = ({ data, container, imagesPath, labelLimit = 8, rankDir = 'LR', vie
   setupUI(zoom, svg);
 
   if (viewProperties) {
-    renderProperties(inner, g);
+    renderProperties(inner, g, useTippy);
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,10 @@ const draw = (data, container, imagesPath, labelLimit = 8, rankDir = 'LR') => {
   // Create white backgrounds for all of the node labels so that text legible
   setNodeLabelBkg('white');
 
+  nodes.forEach((node) => {
+    console.log(node.description);
+  });
+
   // calculate the new edges using control and ownership values
   // this section could do with a refactor and move more of the logic into edges.js
   edges.forEach((edge, index) => {

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -163,8 +163,7 @@ export const getOwnershipEdges = (bodsData) => {
       description: {
         statementDate,
         recordId,
-        identifiers: recordDetails.identifiers,
-        interests: recordDetails.interests,
+        interests: recordDetails?.interests || interests || [],
       },
     };
   });

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -159,6 +159,13 @@ export const getOwnershipEdges = (bodsData) => {
       target,
       config: edgeConfig,
       replaces: replaces,
+      fullDescription: statement,
+      description: {
+        statementDate,
+        recordId,
+        identifiers: recordDetails.identifiers,
+        interests: recordDetails.interests,
+      },
     };
   });
 

--- a/src/model/nodes/nodes.js
+++ b/src/model/nodes/nodes.js
@@ -120,6 +120,12 @@ export const getPersonNodes = (bodsData) => {
       replaces: replaces,
       nodeType: iconType(personTypeData),
       countryCode: countryCode,
+      description: {
+        statementDate: statement.statementDate,
+        recordId: statement.recordId,
+        identifiers: statement.identifiers,
+        interests: statement.interests,
+      },
     };
   });
 
@@ -182,6 +188,12 @@ export const getEntityNodes = (bodsData) => {
       countryCode: countryCode,
       config: nodeConfig,
       replaces: replaces,
+      description: {
+        statementDate: statement.statementDate,
+        recordId: statement.recordId,
+        identifiers: statement.identifiers,
+        interests: statement.interests,
+      },
     };
   });
 

--- a/src/model/nodes/nodes.js
+++ b/src/model/nodes/nodes.js
@@ -120,11 +120,12 @@ export const getPersonNodes = (bodsData) => {
       replaces: replaces,
       nodeType: iconType(personTypeData),
       countryCode: countryCode,
+      fullDescription: statement,
       description: {
-        statementDate: statement.statementDate,
-        recordId: statement.recordId,
-        identifiers: statement.identifiers,
-        interests: statement.interests,
+        statementDate,
+        recordId,
+        identifiers: recordDetails.identifiers,
+        interests: recordDetails.interests,
       },
     };
   });
@@ -188,11 +189,12 @@ export const getEntityNodes = (bodsData) => {
       countryCode: countryCode,
       config: nodeConfig,
       replaces: replaces,
+      fullDescription: statement,
       description: {
-        statementDate: statement.statementDate,
-        recordId: statement.recordId,
-        identifiers: statement.identifiers,
-        interests: statement.interests,
+        statementDate,
+        recordId,
+        identifiers: recordDetails.identifiers,
+        interests: recordDetails.interests,
       },
     };
   });

--- a/src/model/nodes/nodes.js
+++ b/src/model/nodes/nodes.js
@@ -124,8 +124,7 @@ export const getPersonNodes = (bodsData) => {
       description: {
         statementDate,
         recordId,
-        identifiers: recordDetails.identifiers,
-        interests: recordDetails.interests,
+        identifiers: recordDetails?.identifiers || statement.identifiers || [],
       },
     };
   });
@@ -193,8 +192,7 @@ export const getEntityNodes = (bodsData) => {
       description: {
         statementDate,
         recordId,
-        identifiers: recordDetails.identifiers,
-        interests: recordDetails.interests,
+        identifiers: recordDetails?.identifiers || statement.identifiers || [],
       },
     };
   });

--- a/src/render/renderGraph.js
+++ b/src/render/renderGraph.js
@@ -28,6 +28,7 @@ export const setNodes = (nodes, g) => {
       nodeType: node.nodeType,
       countryCode: node.countryCode,
       description: node.description,
+      fullDescription: node.fullDescription,
       ...node.config,
     });
   });
@@ -40,6 +41,7 @@ export const setEdges = (edges, g) => {
       class: edge.class || '',
       edgeType: edge.interestRelationship,
       description: edge.description,
+      fullDescription: edge.fullDescription,
       ...edge.config,
     });
   });

--- a/src/render/renderGraph.js
+++ b/src/render/renderGraph.js
@@ -21,6 +21,7 @@ export const setupGraph = (rankDir) => {
 export const setNodes = (nodes, g) => {
   nodes.forEach((node) => {
     g.setNode(node.recordId || node.id, {
+      id: node.recordId || node.id,
       label: node.label,
       class: node.class || '',
       labelType: node.labelType || 'string',
@@ -35,8 +36,10 @@ export const setNodes = (nodes, g) => {
 export const setEdges = (edges, g) => {
   edges.forEach((edge) => {
     g.setEdge(edge.source, edge.target, {
+      id: edge.recordId || edge.id,
       class: edge.class || '',
       edgeType: edge.interestRelationship,
+      description: edge.description,
       ...edge.config,
     });
   });

--- a/src/render/renderGraph.js
+++ b/src/render/renderGraph.js
@@ -21,7 +21,7 @@ export const setupGraph = (rankDir) => {
 export const setNodes = (nodes, g) => {
   nodes.forEach((node) => {
     g.setNode(node.recordId || node.id, {
-      id: node.recordId || node.id,
+      id: `node_${node.recordId || node.id}`,
       label: node.label,
       class: node.class || '',
       labelType: node.labelType || 'string',
@@ -37,7 +37,7 @@ export const setNodes = (nodes, g) => {
 export const setEdges = (edges, g) => {
   edges.forEach((edge) => {
     g.setEdge(edge.source, edge.target, {
-      id: edge.recordId || edge.id,
+      id: `edge_${edge.recordId || edge.id}`,
       class: edge.class || '',
       edgeType: edge.interestRelationship,
       description: edge.description,

--- a/src/render/renderGraph.js
+++ b/src/render/renderGraph.js
@@ -26,6 +26,7 @@ export const setNodes = (nodes, g) => {
       labelType: node.labelType || 'string',
       nodeType: node.nodeType,
       countryCode: node.countryCode,
+      description: node.description,
       ...node.config,
     });
   });

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -51,18 +51,33 @@ export const setupUI = (zoom, svg) => {
 };
 
 export const renderProperties = (inner, g) => {
+  const disclosureWidget = document.querySelector('#disclosure-widget');
+
   const nodes = inner.selectAll('g.node');
   nodes.each((d, i) => {
     const node = g.node(d);
 
-    const content = JSON.stringify(node.description, null, 2);
+    const description = JSON.stringify(node.description, null, 2);
+    const fullDescription = JSON.stringify(node.fullDescription, null, 2);
 
-    tippy(node.elem, {
-      content: `<pre>${content}</pre>`,
+    const tippyInstance = tippy(node.elem, {
+      content: `<div class="button-container"><button id="close-tooltip">&times;</button></div><pre>${description}</pre>`,
       allowHTML: true,
-      trigger: 'click',
+      trigger: 'manual',
+      hideOnClick: false,
       interactive: true,
       appendTo: document.body,
+      onShow: () => {
+        disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
+      },
+    });
+
+    node.elem.addEventListener('click', () => {
+      tippyInstance.show();
+
+      document.getElementById('close-tooltip').addEventListener('click', () => {
+        tippyInstance.hide();
+      });
     });
   });
 
@@ -70,14 +85,27 @@ export const renderProperties = (inner, g) => {
   edges.each((d, i) => {
     const edge = g.edge(d.v, d.w);
 
-    const content = JSON.stringify(g.edge(d.v, d.w).description, null, 2);
+    const description = JSON.stringify(edge.description, null, 2);
+    const fullDescription = JSON.stringify(edge.fullDescription, null, 2);
 
-    tippy(edge.elem, {
-      content: `<pre>${content}</pre>`,
+    const tippyInstance = tippy(edge.elem, {
+      content: `<div class="button-container"><button id="close-tooltip">&times;</button></div><pre>${description}</pre>`,
       allowHTML: true,
-      trigger: 'click',
+      trigger: 'manual',
+      hideOnClick: false,
       interactive: true,
       appendTo: document.body,
+      onShow: () => {
+        disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
+      },
+    });
+
+    edge.elem.addEventListener('click', () => {
+      tippyInstance.show();
+
+      document.getElementById('close-tooltip').addEventListener('click', () => {
+        tippyInstance.hide();
+      });
     });
   });
 };

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -91,9 +91,9 @@ const getDescription = (description) => {
   }
 
   // Output the descriptions subset as key value pairs on new lines
-  return `Statement date: ${description.statementDate}\nRecord ID: ${description.recordId}\n${
-    identifiers.length > 0 ? identifiersOutput : ''
-  }${interests.length > 0 ? interestsOutput : ''}`;
+  return `Statement date: ${description.statementDate}\n${
+    description.recordId !== null ? 'Record ID: ' + description.recordId + '\n' : ''
+  }${identifiers.length > 0 ? identifiersOutput : ''}${interests.length > 0 ? interestsOutput : ''}`;
 };
 
 // Configure tippy.js

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -1,3 +1,7 @@
+import tippy from 'tippy.js';
+import 'tippy.js/dist/tippy.css';
+import * as d3 from 'd3';
+
 import { SvgSaver } from '../utils/svgsaver';
 
 export const setupUI = (zoom, svg) => {
@@ -43,5 +47,37 @@ export const setupUI = (zoom, svg) => {
     if (e.key === 'Enter' || e.key === 'Space') {
       svgsaver.asPng(svgElement, 'bods.png');
     }
+  });
+};
+
+export const renderProperties = (inner, g) => {
+  const nodes = inner.selectAll('g.node');
+  nodes.each((d, i) => {
+    const node = g.node(d);
+
+    const content = JSON.stringify(node.description, null, 2);
+
+    tippy(node.elem, {
+      content: `<pre>${content}</pre>`,
+      allowHTML: true,
+      trigger: 'click',
+      interactive: true,
+      appendTo: document.body,
+    });
+  });
+
+  const edges = inner.selectAll('g.edgePath');
+  edges.each((d, i) => {
+    const edge = g.edge(d.v, d.w);
+
+    const content = JSON.stringify(g.edge(d.v, d.w).description, null, 2);
+
+    tippy(edge.elem, {
+      content: `<pre>${content}</pre>`,
+      allowHTML: true,
+      trigger: 'click',
+      interactive: true,
+      appendTo: document.body,
+    });
   });
 };

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -88,6 +88,7 @@ const getDescription = (description) => {
   }${interests.length > 0 ? interestsOutput : ''}`;
 };
 
+// Configure tippy.js
 const setTippyInstance = (element, content) => {
   return tippy(element, {
     content: `<div class="button-container"><button class="close-tooltip">&times;</button></div><pre>${content}</pre>`,
@@ -100,6 +101,7 @@ const setTippyInstance = (element, content) => {
   });
 };
 
+//  Generic function to check if elements (multiple) exist in the DOM
 function waitForElementsToExist(selector, callback) {
   if (document.querySelectorAll(selector)) {
     return callback(document.querySelectorAll(selector));
@@ -119,20 +121,23 @@ export const renderProperties = (inner, g, useTippy) => {
   const nodes = inner.selectAll('g.node');
   nodes.each((d, i) => {
     const node = g.node(d);
-
     const description = getDescription(node.description);
     const fullDescription = JSON.stringify(node.fullDescription, null, 2);
 
     node.elem.addEventListener('click', () => {
+      // Populate disclosure widget with node `fullDescription` JSON
       disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
 
       // Only use tippy.js if the useTippy property is true
       if (useTippy) {
+        // Pre-emptively hide any rogue open tooltips
         hideAll();
+
+        // Create tooltip instance and display it
         const tippyInstance = setTippyInstance(node.elem, description);
         tippyInstance.show();
 
-        // Wait until the tooltip is displayed before attaching a close event to the button
+        // Wait until the tooltip button exists before attaching a close event
         waitForElementsToExist('.close-tooltip', (elements) => {
           elements.forEach((element) => {
             element.addEventListener('click', () => {
@@ -147,19 +152,23 @@ export const renderProperties = (inner, g, useTippy) => {
   const edges = inner.selectAll('g.edgePath');
   edges.each((d, i) => {
     const edge = g.edge(d.v, d.w);
-
     const description = getDescription(edge.description);
     const fullDescription = JSON.stringify(edge.fullDescription, null, 2);
 
     edge.elem.addEventListener('click', () => {
+      // Populate disclosure widget with edge `fullDescription` JSON
       disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
 
+      // Only use tippy.js if the useTippy property is true
       if (useTippy) {
+        // Pre-emptively hide any rogue open tooltips
         hideAll();
+
+        // Create tooltip instance and display it
         const tippyInstance = setTippyInstance(edge.elem, description);
         tippyInstance.show();
 
-        // Wait until the tooltip is displayed before attaching a close event to the button
+        // Wait until the tooltip button exists before attaching a close event
         waitForElementsToExist('.close-tooltip', (elements) => {
           elements.forEach((element) => {
             element.addEventListener('click', () => {

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -116,9 +116,11 @@ export const renderProperties = (inner, g, useTippy) => {
         hideAll();
         tippyInstance.show();
 
-        document.getElementById('close-tooltip').addEventListener('click', () => {
-          tippyInstance.hide();
-        });
+        setTimeout(() => {
+          document.getElementById('close-tooltip').addEventListener('click', () => {
+            hideAll();
+          });
+        }, 0);
       });
     }
   });
@@ -148,9 +150,11 @@ export const renderProperties = (inner, g, useTippy) => {
         hideAll();
         tippyInstance.show();
 
-        document.getElementById('close-tooltip').addEventListener('click', () => {
-          tippyInstance.hide();
-        });
+        setTimeout(() => {
+          document.getElementById('close-tooltip').addEventListener('click', () => {
+            hideAll();
+          });
+        }, 0);
       });
     }
   });

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -1,6 +1,6 @@
-import tippy from 'tippy.js';
+import tippy, { hideAll } from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
-import * as d3 from 'd3';
+import 'tippy.js/themes/light-border.css';
 
 import { SvgSaver } from '../utils/svgsaver';
 
@@ -66,6 +66,7 @@ export const renderProperties = (inner, g) => {
       trigger: 'manual',
       hideOnClick: false,
       interactive: true,
+      theme: 'light-border',
       appendTo: document.body,
       onShow: () => {
         disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
@@ -73,6 +74,7 @@ export const renderProperties = (inner, g) => {
     });
 
     node.elem.addEventListener('click', () => {
+      hideAll();
       tippyInstance.show();
 
       document.getElementById('close-tooltip').addEventListener('click', () => {
@@ -94,6 +96,7 @@ export const renderProperties = (inner, g) => {
       trigger: 'manual',
       hideOnClick: false,
       interactive: true,
+      theme: 'light-border',
       appendTo: document.body,
       onShow: () => {
         disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
@@ -101,6 +104,7 @@ export const renderProperties = (inner, g) => {
     });
 
     edge.elem.addEventListener('click', () => {
+      hideAll();
       tippyInstance.show();
 
       document.getElementById('close-tooltip').addEventListener('click', () => {

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -50,6 +50,44 @@ export const setupUI = (zoom, svg) => {
   });
 };
 
+const getDescription = (description) => {
+  // Extract identifiers from description and output text on newlines
+  let identifiers = [];
+  let identifiersOutput = '';
+  if (typeof description.identifiers !== 'undefined' && description.identifiers !== null) {
+    identifiers = description.identifiers.map((identifier, index) => ({
+      [`Identifier ${index + 1}`]: `(${identifier.scheme}) ${identifier.id}`,
+    }));
+    identifiers.forEach((item) => {
+      const key = Object.keys(item)[0];
+      const value = item[key];
+      identifiersOutput += `${key}: ${value}\n`;
+    });
+  }
+
+  // Extract interests from description and output text on newlines
+  let interests = [];
+  let interestsOutput = '';
+  if (typeof description.interests !== 'undefined' && description.interests !== null) {
+    interests = description.interests.map((interest, index) => ({
+      [`Interest ${index + 1} Type`]: `${interest.type}\n`,
+      [`Interest ${index + 1} Start Date`]: `${interest.startDate}\n`,
+    }));
+    interests.forEach((item) => {
+      for (const key in item) {
+        if (item.hasOwnProperty(key)) {
+          interestsOutput += `${key}: ${item[key]}`;
+        }
+      }
+    });
+  }
+
+  // Output the descriptions subset as key value pairs on new lines
+  return `Statement date: ${description.statementDate}\nRecord ID: ${description.recordId}\n${
+    identifiers.length > 0 ? identifiersOutput : ''
+  }${interests.length > 0 ? interestsOutput : ''}`;
+};
+
 export const renderProperties = (inner, g, useTippy) => {
   const disclosureWidget = document.querySelector('#disclosure-widget');
 
@@ -57,7 +95,7 @@ export const renderProperties = (inner, g, useTippy) => {
   nodes.each((d, i) => {
     const node = g.node(d);
 
-    const description = JSON.stringify(node.description, null, 2);
+    const description = getDescription(node.description);
     const fullDescription = JSON.stringify(node.fullDescription, null, 2);
 
     if (useTippy) {
@@ -89,7 +127,7 @@ export const renderProperties = (inner, g, useTippy) => {
   edges.each((d, i) => {
     const edge = g.edge(d.v, d.w);
 
-    const description = JSON.stringify(edge.description, null, 2);
+    const description = getDescription(edge.description);
     const fullDescription = JSON.stringify(edge.fullDescription, null, 2);
 
     if (useTippy) {

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -50,7 +50,7 @@ export const setupUI = (zoom, svg) => {
   });
 };
 
-export const renderProperties = (inner, g) => {
+export const renderProperties = (inner, g, useTippy) => {
   const disclosureWidget = document.querySelector('#disclosure-widget');
 
   const nodes = inner.selectAll('g.node');
@@ -60,27 +60,29 @@ export const renderProperties = (inner, g) => {
     const description = JSON.stringify(node.description, null, 2);
     const fullDescription = JSON.stringify(node.fullDescription, null, 2);
 
-    const tippyInstance = tippy(node.elem, {
-      content: `<div class="button-container"><button id="close-tooltip">&times;</button></div><pre>${description}</pre>`,
-      allowHTML: true,
-      trigger: 'manual',
-      hideOnClick: false,
-      interactive: true,
-      theme: 'light-border',
-      appendTo: document.body,
-      onShow: () => {
-        disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
-      },
-    });
-
-    node.elem.addEventListener('click', () => {
-      hideAll();
-      tippyInstance.show();
-
-      document.getElementById('close-tooltip').addEventListener('click', () => {
-        tippyInstance.hide();
+    if (useTippy) {
+      const tippyInstance = tippy(node.elem, {
+        content: `<div class="button-container"><button id="close-tooltip">&times;</button></div><pre>${description}</pre>`,
+        allowHTML: true,
+        trigger: 'manual',
+        hideOnClick: false,
+        interactive: true,
+        theme: 'light-border',
+        appendTo: document.body,
+        onShow: () => {
+          disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
+        },
       });
-    });
+
+      node.elem.addEventListener('click', () => {
+        hideAll();
+        tippyInstance.show();
+
+        document.getElementById('close-tooltip').addEventListener('click', () => {
+          tippyInstance.hide();
+        });
+      });
+    }
   });
 
   const edges = inner.selectAll('g.edgePath');
@@ -90,26 +92,28 @@ export const renderProperties = (inner, g) => {
     const description = JSON.stringify(edge.description, null, 2);
     const fullDescription = JSON.stringify(edge.fullDescription, null, 2);
 
-    const tippyInstance = tippy(edge.elem, {
-      content: `<div class="button-container"><button id="close-tooltip">&times;</button></div><pre>${description}</pre>`,
-      allowHTML: true,
-      trigger: 'manual',
-      hideOnClick: false,
-      interactive: true,
-      theme: 'light-border',
-      appendTo: document.body,
-      onShow: () => {
-        disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
-      },
-    });
-
-    edge.elem.addEventListener('click', () => {
-      hideAll();
-      tippyInstance.show();
-
-      document.getElementById('close-tooltip').addEventListener('click', () => {
-        tippyInstance.hide();
+    if (useTippy) {
+      const tippyInstance = tippy(edge.elem, {
+        content: `<div class="button-container"><button id="close-tooltip">&times;</button></div><pre>${description}</pre>`,
+        allowHTML: true,
+        trigger: 'manual',
+        hideOnClick: false,
+        interactive: true,
+        theme: 'light-border',
+        appendTo: document.body,
+        onShow: () => {
+          disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
+        },
       });
-    });
+
+      edge.elem.addEventListener('click', () => {
+        hideAll();
+        tippyInstance.show();
+
+        document.getElementById('close-tooltip').addEventListener('click', () => {
+          tippyInstance.hide();
+        });
+      });
+    }
   });
 };

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -69,10 +69,18 @@ const getDescription = (description) => {
   let interests = [];
   let interestsOutput = '';
   if (description.interests) {
-    interests = description.interests.map((interest, index) => ({
-      [`Interest ${index + 1} Type`]: `${interest.type}\n`,
-      [`Interest ${index + 1} Start Date`]: `${interest.startDate}\n`,
-    }));
+    interests = description.interests.map((interest, index) => {
+      if (interest.startDate) {
+        return {
+          [`Interest ${index + 1} Type`]: `${interest.type}\n`,
+          [`Interest ${index + 1} Start Date`]: `${interest.startDate}\n`,
+        };
+      } else {
+        return {
+          [`Interest ${index + 1} Type`]: `${interest.type}\n`,
+        };
+      }
+    });
     interests.forEach((item) => {
       for (const key in item) {
         if (item.hasOwnProperty(key)) {
@@ -152,31 +160,34 @@ export const renderProperties = (inner, g, useTippy) => {
   const edges = inner.selectAll('g.edgePath');
   edges.each((d, i) => {
     const edge = g.edge(d.v, d.w);
+    const edgeInstances = document.querySelectorAll(`#${edge.elem.id}`);
     const description = getDescription(edge.description);
     const fullDescription = JSON.stringify(edge.fullDescription, null, 2);
 
-    edge.elem.addEventListener('click', () => {
-      // Populate disclosure widget with edge `fullDescription` JSON
-      disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
+    edgeInstances.forEach((edgeInstance) => {
+      edgeInstance.addEventListener('click', () => {
+        // Populate disclosure widget with edge `fullDescription` JSON
+        disclosureWidget.innerHTML = `<details open><summary>Properties</summary><pre>${fullDescription}</pre></details>`;
 
-      // Only use tippy.js if the useTippy property is true
-      if (useTippy) {
-        // Pre-emptively hide any rogue open tooltips
-        hideAll();
+        // Only use tippy.js if the useTippy property is true
+        if (useTippy) {
+          // Pre-emptively hide any rogue open tooltips
+          hideAll();
 
-        // Create tooltip instance and display it
-        const tippyInstance = setTippyInstance(edge.elem, description);
-        tippyInstance.show();
+          // Create tooltip instance and display it
+          const tippyInstance = setTippyInstance(edgeInstance, description);
+          tippyInstance.show();
 
-        // Wait until the tooltip button exists before attaching a close event
-        waitForElementsToExist('.close-tooltip', (elements) => {
-          elements.forEach((element) => {
-            element.addEventListener('click', () => {
-              hideAll();
+          // Wait until the tooltip button exists before attaching a close event
+          waitForElementsToExist('.close-tooltip', (elements) => {
+            elements.forEach((element) => {
+              element.addEventListener('click', () => {
+                hideAll();
+              });
             });
           });
-        });
-      }
+        }
+      });
     });
   });
 };


### PR DESCRIPTION
This PR closes #55 with the following changes:

- Adds `description` and `fullDescription` properties to each node and edge, which can be accessed programmatically to display a subset of statement properties (as defined in related issue), or all properties respectively.
- Adds an option to show a `<details>` panel to display `fullDescription`
- Adds an option to use [tippy.js](https://atomiks.github.io/tippyjs/) tooltips to display `description`
- Changes `draw()` function to take an object rather than a list of  multiple parameters
- Displays `description` as formatted key-value pairs
- Displays `fullDescription` as JSON

