### PR TITLE
Interest types mapping

### DIFF
--- a/src/codelists/interestTypes.js
+++ b/src/codelists/interestTypes.js
@@ -163,30 +163,30 @@ export default {
   },
   'influence-or-control': {
     description: 'Influence or control',
-    category: '',
+    category: 'control',
   },
   'settlor-of-trust': {
     description: 'Settlor of trust',
-    category: '',
+    category: 'control',
   },
   'trustee-of-trust': {
     description: 'Trustee of a trust',
-    category: '',
+    category: 'control',
   },
   'protector-of-trust': {
     description: 'Protector of a trust',
-    category: '',
+    category: 'control',
   },
   'beneficiary-of-trust': {
     description: 'Beneficiary of a trust',
-    category: '',
+    category: 'ownership',
   },
   'other-influence-or-control-of-trust': {
     description: 'Other influence or control of a trust',
-    category: '',
+    category: 'control',
   },
   'rights-to-surplus-assets': {
     description: 'Rights to surplus assets',
-    category: '',
+    category: 'ownership',
   },
 };

--- a/src/codelists/interestTypes.js
+++ b/src/codelists/interestTypes.js
@@ -1,49 +1,192 @@
 // This is currently a mix of the interestType codelists from v0.3 and earlier
 // N.B. Not respresentative of a single BODS version. This is to ensure backwards compatibility.
 export default {
-  shareholding: 'Shareholding',
-  votingRights: 'Voting rights',
-  appointmentOfBoard: 'Appointment of board',
-  otherInfluenceOrControl: 'Other influence or control',
-  seniorManagingOfficial: 'Senior managing official',
-  settlor: 'Settlor',
-  trustee: 'Trustee',
-  protector: 'Protector',
-  beneficiaryOfLegalArrangement: 'Beneficiary of a legal arrangement',
-  rightsToSurplusAssetsOnDissolution: 'Rights to surplus assets on dissolution',
-  rightsToProfitOrIncome: 'Rights to receive profits or income',
-  rightsGrantedByContract: 'Rights granted by contract',
-  conditionalRightsGrantedByContract: 'Conditional rights granted by contract',
-  controlViaCompanyRulesOrArticles: 'Control via company rules or articles',
-  controlByLegalFramework: 'Control by legal framework',
-  boardMember: 'Board member',
-  boardChair: 'Board chair',
-  unknownInterest: 'Unknown interest',
-  unpublishedInterest: 'Unpublished interest',
-  enjoymentAndUseOfAssets: 'Enjoyment and use of assets',
-  rightToProfitOrIncomeFromAssets: 'Right to profit or income from assets',
-  'voting-rights': 'Voting rights',
-  'appointment-of-board': 'Appointment of board',
-  'other-influence-or-control': 'Other influence or control',
-  'senior-managing-official': 'Senior managing official',
-  'beneficiary-of-legal-arrangement': 'Beneficiary of a legal arrangement',
-  'rights-to-surplus-assets-on-dissolution': 'Rights to surplus assets on dissolution',
-  'rights-to-profit-or-income': 'Rights to receive profits or income',
-  'rights-granted-by-contract': 'Rights granted by contract',
-  'conditional-rights-granted-by-contract': 'Conditional rights granted by contract',
-  'control-via-company-rules-or-articles': 'Control via company rules or articles',
-  'control-by-legal-framework': 'Control by legal framework',
-  'board-member': 'Board member',
-  'board-chair': 'Board chair',
-  'unknown-interest': 'Unknown interest',
-  'unpublished-interest': 'Unpublished interest',
-  'enjoyment-and-use-of-assets': 'Enjoyment and use of assets',
-  'right-to-profit-or-income-from-assets': 'Right to profit or income from assets',
-  'influence-or-control': 'Influence or control',
-  'settlor-of-trust': 'Settlor of trust',
-  'trustee-of-trust': 'Trustee of a trust',
-  'protector-of-trust': 'Protector of a trust',
-  'beneficiary-of-trust': 'Beneficiary of a trust',
-  'other-influence-or-control-of-trust': 'Other influence or control of a trust',
-  'rights-to-surplus-assets': 'Rights to surplus assets',
+  shareholding: {
+    description: 'Shareholding',
+    category: 'ownership',
+  },
+  votingRights: {
+    description: 'Voting rights',
+    category: 'control',
+  },
+  appointmentOfBoard: {
+    description: 'Appointment of board',
+    category: 'control',
+  },
+  otherInfluenceOrControl: {
+    description: 'Other influence or control',
+    category: 'control',
+  },
+  seniorManagingOfficial: {
+    description: 'Senior managing official',
+    category: 'control',
+  },
+  settlor: {
+    description: 'Settlor',
+    category: 'control',
+  },
+  trustee: {
+    description: 'Trustee',
+    category: 'control',
+  },
+  protector: {
+    description: 'Protector',
+    category: 'control',
+  },
+  beneficiaryOfLegalArrangement: {
+    description: 'Beneficiary of a legal arrangement',
+    category: 'ownership',
+  },
+  rightsToSurplusAssetsOnDissolution: {
+    description: 'Rights to surplus assets on dissolution',
+    category: 'ownership',
+  },
+  rightsToProfitOrIncome: {
+    description: 'Rights to receive profits or income',
+    category: 'ownership',
+  },
+  rightsGrantedByContract: {
+    description: 'Rights granted by contract',
+    category: 'control',
+  },
+  conditionalRightsGrantedByContract: {
+    description: 'Conditional rights granted by contract',
+    category: 'control',
+  },
+  controlViaCompanyRulesOrArticles: {
+    description: 'Control via company rules or articles',
+    category: 'control',
+  },
+  controlByLegalFramework: {
+    description: 'Control by legal framework',
+    category: 'control',
+  },
+  boardMember: {
+    description: 'Board member',
+    category: 'control',
+  },
+  boardChair: {
+    description: 'Board chair',
+    category: 'control',
+  },
+  unknownInterest: {
+    description: 'Unknown interest',
+    category: '',
+  },
+  unpublishedInterest: {
+    description: 'Unpublished interest',
+    category: '',
+  },
+  enjoymentAndUseOfAssets: {
+    description: 'Enjoyment and use of assets',
+    category: 'ownership',
+  },
+  rightToProfitOrIncomeFromAssets: {
+    description: 'Right to profit or income from assets',
+    category: 'ownership',
+  },
+  nominee: {
+    description: 'Nominee',
+    category: 'control',
+  },
+  nominator: {
+    description: 'Nominator',
+    category: 'control',
+  },
+  'voting-rights': {
+    description: 'Voting rights',
+    category: 'control',
+  },
+  'appointment-of-board': {
+    description: 'Appointment of board',
+    category: 'control',
+  },
+  'other-influence-or-control': {
+    description: 'Other influence or control',
+    category: 'control',
+  },
+  'senior-managing-official': {
+    description: 'Senior managing official',
+    category: 'control',
+  },
+  'beneficiary-of-legal-arrangement': {
+    description: 'Beneficiary of a legal arrangement',
+    category: 'ownership',
+  },
+  'rights-to-surplus-assets-on-dissolution': {
+    description: 'Rights to surplus assets on dissolution',
+    category: 'ownership',
+  },
+  'rights-to-profit-or-income': {
+    description: 'Rights to receive profits or income',
+    category: 'ownership',
+  },
+  'rights-granted-by-contract': {
+    description: 'Rights granted by contract',
+    category: 'control',
+  },
+  'conditional-rights-granted-by-contract': {
+    description: 'Conditional rights granted by contract',
+    category: 'control',
+  },
+  'control-via-company-rules-or-articles': {
+    description: 'Control via company rules or articles',
+    category: 'control',
+  },
+  'control-by-legal-framework': {
+    description: 'Control by legal framework',
+    category: 'control',
+  },
+  'board-member': {
+    description: 'Board member',
+    category: 'control',
+  },
+  'board-chair': {
+    description: 'Board chair',
+    category: 'control',
+  },
+  'unknown-interest': {
+    description: 'Unknown interest',
+    category: '',
+  },
+  'unpublished-interest': {
+    description: 'Unpublished interest',
+    category: '',
+  },
+  'enjoyment-and-use-of-assets': {
+    description: 'Enjoyment and use of assets',
+    category: 'ownership',
+  },
+  'right-to-profit-or-income-from-assets': {
+    description: 'Right to profit or income from assets',
+    category: 'ownership',
+  },
+  'influence-or-control': {
+    description: 'Influence or control',
+    category: '',
+  },
+  'settlor-of-trust': {
+    description: 'Settlor of trust',
+    category: '',
+  },
+  'trustee-of-trust': {
+    description: 'Trustee of a trust',
+    category: '',
+  },
+  'protector-of-trust': {
+    description: 'Protector of a trust',
+    category: '',
+  },
+  'beneficiary-of-trust': {
+    description: 'Beneficiary of a trust',
+    category: '',
+  },
+  'other-influence-or-control-of-trust': {
+    description: 'Other influence or control of a trust',
+    category: '',
+  },
+  'rights-to-surplus-assets': {
+    description: 'Rights to surplus assets',
+    category: '',
+  },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const draw = ({
       setDashedLine(element);
     }
 
-    if (interests.type === 'shareholding') {
+    if (interests.some((item) => item.type === 'shareholding')) {
       createOwnershipCurve(
         element,
         index,
@@ -88,7 +88,7 @@ const draw = ({
         config.share.arrowheadShape
       );
     }
-    if (interests.type === 'votingRights') {
+    if (interests.some((item) => item.type === 'votingRights')) {
       createControlCurve(
         element,
         index,
@@ -109,16 +109,18 @@ const draw = ({
     // The unknown interest labels are drawn when the interest type is set to 'unknownInterest' or the data are missing
     // No label is displayed if the interestType is within the interestType codelist but is not shareholding or votingRights
     if (
-      interests.type === 'unknownInterest' ||
-      interests.type === '' ||
-      !interests.type in interestTypesCodelist
+      interests.some((item) => item.type === 'unknownInterest') ||
+      interests.some((item) => item.type === '') ||
+      !interests.some((item) => item.type in interestTypesCodelist)
     ) {
       limitLabels(createUnknownText(svg, index, element));
     }
 
     // This removes the markers from any edges that have either ownership or control
-    const { category } = interests;
-    if (category === 'ownership' || category === 'control') {
+    if (
+      interests.some((item) => item.category === 'ownership') ||
+      interests.some((item) => item.category === 'control')
+    ) {
       removeMarkers(g, source, target);
     }
   });

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const draw = ({
       setDashedLine(element);
     }
 
-    if ('shareholding' in interests) {
+    if (interests.type === 'shareholding') {
       createOwnershipCurve(
         element,
         index,
@@ -88,7 +88,7 @@ const draw = ({
         config.share.arrowheadShape
       );
     }
-    if ('votingRights' in interests) {
+    if (interests.type === 'votingRights') {
       createControlCurve(
         element,
         index,
@@ -109,16 +109,16 @@ const draw = ({
     // The unknown interest labels are drawn when the interest type is set to 'unknownInterest' or the data are missing
     // No label is displayed if the interestType is within the interestType codelist but is not shareholding or votingRights
     if (
-      (interests &&
-        !Object.keys(interests).some((type) => Object.keys(interestTypesCodelist).includes(type))) ||
-      (Object.keys(interests).length === 1 && Object.keys(interests)[0] === 'unknownInterest')
+      interests.type === 'unknownInterest' ||
+      interests.type === '' ||
+      !interests.type in interestTypesCodelist
     ) {
       limitLabels(createUnknownText(svg, index, element));
     }
 
     // This removes the markers from any edges that have either ownership or control
-    const { shareholding, votingRights } = interests;
-    if (shareholding || votingRights) {
+    const { category } = interests;
+    if (category === 'ownership' || category === 'control') {
       removeMarkers(g, source, target);
     }
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import { getNodes } from './model/nodes/nodes';
 import { checkInterests, getEdges } from './model/edges/edges';
-import interestTypesCodelist from './codelists/interestTypes';
 import {
   setupD3,
   defineArrowHeads,
@@ -110,8 +109,9 @@ const draw = ({
     // No label is displayed if the interestType is within the interestType codelist but is not shareholding or votingRights
     if (
       interests.some((item) => item.type === 'unknownInterest') ||
+      interests.some((item) => item.type === 'unpublishedInterest') ||
       interests.some((item) => item.type === '') ||
-      !interests.some((item) => item.type in interestTypesCodelist)
+      interests.some((item) => !item.type)
     ) {
       limitLabels(createUnknownText(svg, index, element));
     }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   defineArrowHeads,
   createOwnershipCurve,
   createControlCurve,
+  createUnknownCurve,
   createControlText,
   createOwnText,
   createUnknownText,
@@ -64,9 +65,11 @@ const draw = ({
       shareText,
       controlStroke,
       controlText,
+      unknownStroke,
       config,
     } = edge;
 
+    const unknownOffset = unknownStroke / 2;
     const shareOffset = shareStroke / 2;
     const controlOffset = -(controlStroke / 2);
     const element = g.edge(source, target).elem;
@@ -93,6 +96,17 @@ const draw = ({
         config.control.arrowheadShape
       );
     }
+    if (interests.some((item) => item.category === '')) {
+      createUnknownCurve(
+        element,
+        index,
+        config.unknown.positiveStroke,
+        config.unknown.strokeValue,
+        unknownOffset,
+        checkInterests(interestRelationship),
+        config.unknown.arrowheadShape
+      );
+    }
 
     // this creates the edge labels, and will allow the labels to be turned off if the node count exceeds the labelLimit
     const limitLabels = (createLabel) => g.nodeCount() < labelLimit && createLabel;
@@ -108,7 +122,7 @@ const draw = ({
       interests.some((item) => item.type === '') ||
       interests.some((item) => !item.type)
     ) {
-      limitLabels(createUnknownText(svg, index, element));
+      limitLabels(createUnknownText(svg, index));
     }
 
     // This removes the markers from any edges that have either ownership or control

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ const draw = ({
         config.control.arrowheadShape
       );
     }
-    if (interests.some((item) => item.category === '')) {
+    if (!interests.length || interests.some((item) => item.category === '')) {
       createUnknownCurve(
         element,
         index,
@@ -117,6 +117,7 @@ const draw = ({
     // The unknown interest labels are drawn when the interest type is set to 'unknownInterest' or the data are missing
     // No label is displayed if the interestType is within the interestType codelist but is not shareholding or votingRights
     if (
+      !interests.length ||
       interests.some((item) => item.type === 'unknownInterest') ||
       interests.some((item) => item.type === 'unpublishedInterest') ||
       interests.some((item) => item.type === '') ||

--- a/src/index.js
+++ b/src/index.js
@@ -114,18 +114,6 @@ const draw = ({
     limitLabels(createControlText(svg, index, controlText));
     limitLabels(createOwnText(svg, index, shareText));
 
-    // The unknown interest labels are drawn when the interest type is set to 'unknownInterest' or the data are missing
-    // No label is displayed if the interestType is within the interestType codelist but is not shareholding or votingRights
-    if (
-      !interests.length ||
-      interests.some((item) => item.type === 'unknownInterest') ||
-      interests.some((item) => item.type === 'unpublishedInterest') ||
-      interests.some((item) => item.type === '') ||
-      interests.some((item) => !item.type)
-    ) {
-      limitLabels(createUnknownText(svg, index));
-    }
-
     // This removes the markers from any edges that have either ownership or control
     if (
       interests.some((item) => item.category === 'ownership') ||

--- a/src/index.js
+++ b/src/index.js
@@ -71,12 +71,7 @@ const draw = ({
     const controlOffset = -(controlStroke / 2);
     const element = g.edge(source, target).elem;
 
-    // set all indirect relationships to dashed lines
-    if (checkInterests(interestRelationship)) {
-      setDashedLine(element);
-    }
-
-    if (interests.some((item) => item.type === 'shareholding')) {
+    if (interests.some((item) => item.category === 'ownership')) {
       createOwnershipCurve(
         element,
         index,
@@ -87,7 +82,7 @@ const draw = ({
         config.share.arrowheadShape
       );
     }
-    if (interests.some((item) => item.type === 'votingRights')) {
+    if (interests.some((item) => item.category === 'control')) {
       createControlCurve(
         element,
         index,

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -120,6 +120,7 @@ export const getOwnershipEdges = (bodsData) => {
     const mappedInterests = getInterests(interestsData);
 
     // work out the ownership stroke and text
+    const unknownStroke = getStroke(mappedInterests.find((item) => item.category === ''));
     const shareStroke = getStroke(mappedInterests.find((item) => item.category === 'ownership'));
     const shareText = getText(
       mappedInterests.find((item) => item.category === 'ownership'),
@@ -160,6 +161,13 @@ export const getOwnershipEdges = (bodsData) => {
         positiveStroke,
       };
     }
+    if (mappedInterests.some((item) => item.category === '')) {
+      edgeConfig.unknown = {
+        arrowheadShape: 'blackFull',
+        strokeValue: '#000',
+        positiveStroke: unknownStroke,
+      };
+    }
 
     return {
       id: statementId || statementID,
@@ -172,6 +180,7 @@ export const getOwnershipEdges = (bodsData) => {
       controlText,
       shareText,
       shareStroke,
+      unknownStroke,
       source,
       target,
       config: { ...edgeConfig },

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -120,15 +120,15 @@ export const getOwnershipEdges = (bodsData) => {
     const mappedInterests = getInterests(interestsData);
 
     // work out the ownership stroke and text
-    const shareStroke = getStroke(mappedInterests.find((item) => item.type === 'shareholding'));
+    const shareStroke = getStroke(mappedInterests.find((item) => item.category === 'ownership'));
     const shareText = getText(
-      mappedInterests.find((item) => item.type === 'shareholding'),
+      mappedInterests.find((item) => item.category === 'ownership'),
       'Owns'
     );
 
-    const controlStroke = getStroke(mappedInterests.find((item) => item.type === 'votingRights'));
+    const controlStroke = getStroke(mappedInterests.find((item) => item.category === 'control'));
     const controlText = getText(
-      mappedInterests.find((item) => item.type === 'votingRights'),
+      mappedInterests.find((item) => item.category === 'control'),
       'Controls'
     );
 

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -56,7 +56,7 @@ const getText = (shareValues, type) => {
     ) {
       return `${type} ${minimum || exclusiveMinimum} - ${maximum || exclusiveMaximum}%`;
     } else {
-      return ``;
+      return `${type}`;
     }
   } else {
     return `${type} ${exact}%`;

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -17,7 +17,11 @@ const getInterests = (interests) => {
         ...interests.reduce((data, interest) => {
           const { type, share, endDate } = interest;
           const typeKey = type === 'voting-rights' ? 'votingRights' : type;
-          return { ...data, [typeKey]: share };
+          const typeCategory = {
+            votingRights: 'control',
+            shareholding: 'ownership',
+          };
+          return { ...data, type: typeKey, share, category: typeCategory[type] };
         }, {}),
       };
 };
@@ -109,17 +113,18 @@ export const getOwnershipEdges = (bodsData) => {
     }
 
     const mappedInterests = getInterests(interestsData);
+    console.log(mappedInterests)
 
     // work out the ownership stroke and text
-    const { shareholding, votingRights } = mappedInterests;
+    const { type, share, category } = mappedInterests;
 
-    const shareStroke = getStroke(shareholding);
-    const shareText = getText(shareholding, 'Owns');
+    const shareStroke = getStroke(type === 'shareholding' && share);
+    const shareText = getText(type === 'shareholding' && share, 'Owns');
 
-    const controlStroke = getStroke(votingRights);
-    const controlText = getText(votingRights, 'Controls');
+    const controlStroke = getStroke(type === 'votingRights' && share);
+    const controlText = getText(type === 'votingRights' && share, 'Controls');
 
-    if ('shareholding' in mappedInterests) {
+    if (category === 'ownership') {
       const arrowheadColour = shareStroke === 0 ? 'black' : '';
       const arrowheadShape = `${arrowheadColour}${'votingRights' in mappedInterests ? 'Half' : 'Full'}`;
       const strokeValue = shareStroke === 0 ? '#000' : '#652eb1';
@@ -131,7 +136,7 @@ export const getOwnershipEdges = (bodsData) => {
         positiveStroke,
       };
     }
-    if ('votingRights' in mappedInterests) {
+    if (category === 'control') {
       const arrowheadColour = controlStroke === 0 ? 'black' : '';
       const arrowheadShape = `${arrowheadColour}${'votingRights' in mappedInterests ? 'Half' : 'Full'}`;
       const strokeValue = controlStroke === 0 ? '#000' : '#349aee';

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -113,7 +113,6 @@ export const getOwnershipEdges = (bodsData) => {
     }
 
     const mappedInterests = getInterests(interestsData);
-    console.log(mappedInterests)
 
     // work out the ownership stroke and text
     const { type, share, category } = mappedInterests;
@@ -126,7 +125,7 @@ export const getOwnershipEdges = (bodsData) => {
 
     if (category === 'ownership') {
       const arrowheadColour = shareStroke === 0 ? 'black' : '';
-      const arrowheadShape = `${arrowheadColour}${'votingRights' in mappedInterests ? 'Half' : 'Full'}`;
+      const arrowheadShape = `${arrowheadColour}${'ownership' in mappedInterests ? 'Half' : 'Full'}`;
       const strokeValue = shareStroke === 0 ? '#000' : '#652eb1';
       const positiveStroke = shareStroke === 0 ? 1 : shareStroke;
 
@@ -138,7 +137,7 @@ export const getOwnershipEdges = (bodsData) => {
     }
     if (category === 'control') {
       const arrowheadColour = controlStroke === 0 ? 'black' : '';
-      const arrowheadShape = `${arrowheadColour}${'votingRights' in mappedInterests ? 'Half' : 'Full'}`;
+      const arrowheadShape = `${arrowheadColour}${'control' in mappedInterests ? 'Half' : 'Full'}`;
       const strokeValue = controlStroke === 0 ? '#000' : '#349aee';
       const positiveStroke = controlStroke === 0 ? 1 : controlStroke;
 
@@ -162,7 +161,7 @@ export const getOwnershipEdges = (bodsData) => {
       shareStroke,
       source,
       target,
-      config: edgeConfig,
+      config: { ...edgeConfig },
       replaces: replaces,
       fullDescription: statement,
       description: {

--- a/src/model/edges/edges.js
+++ b/src/model/edges/edges.js
@@ -1,6 +1,7 @@
 import { compareVersions } from 'compare-versions';
 import { curveMonotoneX } from 'd3';
 import { closedRecords, latest } from '../../utils/bods';
+import interestTypesCodelist from '../../codelists/interestTypes';
 
 // This sets the style and shape of the edges using D3 parameters
 const edgeConfig = {
@@ -13,16 +14,13 @@ const defaultStroke = 5;
 const getInterests = (interests) => {
   const transformedInterests = interests.reduce((acc, interest) => {
     const { type, share, endDate } = interest;
-    const typeKey = type === 'voting-rights' ? 'votingRights' : type;
-    const typeCategory = {
-      votingRights: 'control',
-      shareholding: 'ownership',
-    };
+    const typeKey = type;
+    const typeCategory = interestTypesCodelist[type]?.category || '';
 
     const transformedInterest = {
       type: typeKey,
       share,
-      category: typeCategory[typeKey],
+      category: typeCategory,
     };
 
     // Add the transformed object to the array

--- a/src/render/renderD3.js
+++ b/src/render/renderD3.js
@@ -224,7 +224,7 @@ export const createControlCurve = (
     .attr('marker-end', `url(#arrow-control-${arrowheadShape})`)
     .attr(
       'style',
-      `fill: none; stroke: ${strokeValue}; stroke-width: 1px; stroke-width: ${positiveStroke}px; ${
+      `fill: none; stroke: ${strokeValue}; stroke-width: ${positiveStroke}px; ${
         dashedInterest ? 'stroke-dasharray: 20,12' : ''
       };`
     )

--- a/src/render/renderD3.js
+++ b/src/render/renderD3.js
@@ -148,6 +148,38 @@ export const defineArrowHeads = (svg) => {
     .attr('stroke', 'none')
     .attr('fill', '#000');
 
+  const unknownBlackHalf = svg
+    .append('defs')
+    .append('marker')
+    .attr('id', 'arrow-unknown-blackHalf')
+    .attr('viewBox', [0, 0, 10, 10])
+    .attr('refX', 8)
+    .attr('refY', 6.1)
+    .attr('markerUnits', 'userSpaceOnUse')
+    .attr('markerWidth', 40)
+    .attr('markerHeight', 40)
+    .attr('orient', 'auto-start-reverse')
+    .append('path')
+    .attr('d', 'M 0 10 L 10 5 L 0 5 z')
+    .attr('stroke', 'none')
+    .attr('fill', '#000');
+
+  const unknownBlackFull = svg
+    .append('defs')
+    .append('marker')
+    .attr('id', 'arrow-unknown-blackFull')
+    .attr('viewBox', [0, 0, 10, 10])
+    .attr('refX', 8)
+    .attr('refY', 5)
+    .attr('markerUnits', 'userSpaceOnUse')
+    .attr('markerWidth', 40)
+    .attr('markerHeight', 40)
+    .attr('orient', 'auto-start-reverse')
+    .append('path')
+    .attr('d', 'M 0 10 L 10 5 L 0 0 z')
+    .attr('stroke', 'none')
+    .attr('fill', '#000');
+
   return {
     half,
     full,
@@ -157,6 +189,8 @@ export const defineArrowHeads = (svg) => {
     blackFull,
     ownBlackHalf,
     ownBlackFull,
+    unknownBlackHalf,
+    unknownBlackFull,
   };
 };
 
@@ -249,6 +283,51 @@ export const createControlCurve = (
     });
 };
 
+export const createUnknownCurve = (
+  element,
+  index,
+  positiveStroke,
+  strokeValue,
+  curveOffset,
+  dashedInterest,
+  arrowheadShape
+) => {
+  console.log(arrowheadShape);
+  d3.select(element)
+    .attr('style', 'opacity: 0;')
+    .clone(true)
+    .attr('style', 'opacity: 1;')
+    .attr('class', 'edgePath control')
+    .select('.path')
+    .attr('id', (d, i) => 'unknownPath' + index)
+    .attr('marker-end', `url(#arrow-unknown-${arrowheadShape})`)
+    .attr(
+      'style',
+      `fill: none; stroke: ${strokeValue}; stroke-width: ${positiveStroke}px; ${
+        dashedInterest ? 'stroke-dasharray: 20,12' : ''
+      };`
+    )
+    .each(function () {
+      const path = d3.select(this);
+      const newBezier = Bezier.SVGtoBeziers(path.attr('d'));
+      const offsetCurve = newBezier.offset(curveOffset);
+      path.attr('d', bezierBuilder(offsetCurve));
+    });
+
+  d3.select(element)
+    .clone(true)
+    .select('.path')
+    .attr('id', (d, i) => 'unknownText' + index)
+    .attr('style', 'fill: none;')
+    .attr('marker-end', '')
+    .each(function () {
+      const path = d3.select(this);
+      const newBezier = Bezier.SVGtoBeziers(path.attr('d'));
+      const offsetCurve = newBezier.offset(-15);
+      path.attr('d', bezierBuilder(offsetCurve));
+    });
+};
+
 export const createControlText = (svg, index, controlText) => {
   svg
     .select('.edgeLabels')
@@ -283,19 +362,19 @@ export const createOwnText = (svg, index, shareText) => {
     .style('fill', '#652eb1');
 };
 
-export const createUnknownText = (svg, index, element) => {
-  d3.select(element)
-    .clone(true)
-    .select('path')
-    .attr('id', `unknown${index}`)
-    .attr('style', 'fill: none;')
-    .attr('marker-end', '')
-    .each(function () {
-      const path = d3.select(this);
-      const newBezier = Bezier.SVGtoBeziers(path.attr('d'));
-      const offsetCurve = newBezier.offset(-10);
-      path.attr('d', bezierBuilder(offsetCurve));
-    });
+export const createUnknownText = (svg, index) => {
+  // d3.select(element)
+  //   .clone(true)
+  //   .select('path')
+  //   .attr('id', `unknown${index}`)
+  //   .attr('style', 'fill: none;')
+  //   .attr('marker-end', '')
+  //   .each(function () {
+  //     const path = d3.select(this);
+  //     const newBezier = Bezier.SVGtoBeziers(path.attr('d'));
+  //     const offsetCurve = newBezier.offset(-10);
+  //     path.attr('d', bezierBuilder(offsetCurve));
+  //   });
   svg
     .select('.edgeLabels')
     .append('g')
@@ -305,7 +384,7 @@ export const createUnknownText = (svg, index, element) => {
     .attr('text-anchor', 'middle')
     .append('textPath')
     .attr('xlink:href', function (d, i) {
-      return '#unknown' + index;
+      return '#unknownText' + index;
     })
     .attr('startOffset', '50%')
     .text(`Interest details unknown`);

--- a/src/render/renderD3.js
+++ b/src/render/renderD3.js
@@ -292,7 +292,6 @@ export const createUnknownCurve = (
   dashedInterest,
   arrowheadShape
 ) => {
-  console.log(arrowheadShape);
   d3.select(element)
     .attr('style', 'opacity: 0;')
     .clone(true)

--- a/src/render/renderD3.js
+++ b/src/render/renderD3.js
@@ -361,34 +361,6 @@ export const createOwnText = (svg, index, shareText) => {
     .style('fill', '#652eb1');
 };
 
-export const createUnknownText = (svg, index) => {
-  // d3.select(element)
-  //   .clone(true)
-  //   .select('path')
-  //   .attr('id', `unknown${index}`)
-  //   .attr('style', 'fill: none;')
-  //   .attr('marker-end', '')
-  //   .each(function () {
-  //     const path = d3.select(this);
-  //     const newBezier = Bezier.SVGtoBeziers(path.attr('d'));
-  //     const offsetCurve = newBezier.offset(-10);
-  //     path.attr('d', bezierBuilder(offsetCurve));
-  //   });
-  svg
-    .select('.edgeLabels')
-    .append('g')
-    .attr('class', 'edgeLabel')
-    .append('text')
-    .attr('class', 'edgeText')
-    .attr('text-anchor', 'middle')
-    .append('textPath')
-    .attr('xlink:href', function (d, i) {
-      return '#unknownText' + index;
-    })
-    .attr('startOffset', '50%')
-    .text(`Interest details unknown`);
-};
-
 export const setNodeLabelBkg = (color) => {
   d3.selectAll('.edgeLabels .edgeLabel .label, .nodes .node .label').each(function (d, i) {
     const label = d3.select(this);


### PR DESCRIPTION
This PR closes #97 with the following changes:
- Add support for interests categories rather than just interests types
- Add support for missing interests
- Add text labels even when no share %, either 'Owns' or 'Controls'
- Fix unknown interests dashed lines & improve support for unknown interests
- Fix edge stroke widths based on share %