### PR TITLE
Improve errors

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 button {
   margin: 10px;
   width: 200px;
@@ -66,6 +70,7 @@ button {
 }
 
 #draw-vis {
+  margin: 10px auto;
   width: 100%;
 }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,9 @@
       <div id="disclosure-widget"></div>
       <button id="download-svg">Download SVG</button>
       <button id="download-png">Download PNG</button>
+      <div class="info-container">
+        <p><a href="https://github.com/openownership/visualisation-tool/blob/master/docs/spec.md#data-requirements">Data requirements</a></p>
+      </div>
     </div>
   </body>
 </html>

--- a/demo/script-tag.html
+++ b/demo/script-tag.html
@@ -23,6 +23,9 @@
         <button id="zoom_out">-</button>
       </div>
       <div id="disclosure-widget"></div>
+      <div class="info-container">
+        <p><a href="https://github.com/openownership/visualisation-tool/blob/master/docs/spec.md#data-requirements">Data requirements</a></p>
+      </div>
     </div>
   </body>
   <script src="bods-dagre.js"></script>

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import {
   createUnspecifiedNode,
 } from './render/renderD3';
 import { setupGraph, setEdges, setNodes } from './render/renderGraph';
-import { setupUI, renderProperties } from './render/renderUI';
+import { setupUI, renderMessage, renderProperties } from './render/renderUI';
 
 import './style.css';
 
@@ -46,7 +46,13 @@ const draw = ({
   setNodes(nodes, g);
 
   // Run the renderer. This is what draws the final graph.
-  render(inner, g);
+  try {
+    render(inner, g);
+  } catch (error) {
+    const message = 'Your data does not have any information that can be drawn.';
+    renderMessage(message);
+    console.error(error);
+  }
 
   // Inject SVG images (for use e.g. as flags)
   injectSVGElements(imagesPath, inner, g);

--- a/src/parse/parse.js
+++ b/src/parse/parse.js
@@ -1,3 +1,5 @@
+import { renderMessage } from '../render/renderUI.js';
+
 export const parse = (data) => {
   let parsed;
 
@@ -5,6 +7,8 @@ export const parse = (data) => {
   try {
     parsed = JSON.parse(data);
   } catch (error) {
+    const message = 'There was an error drawing your data. The data must be a valid JSON array of objects.';
+    renderMessage(message);
     console.error(error);
     return {};
   }

--- a/src/render/renderUI.js
+++ b/src/render/renderUI.js
@@ -127,6 +127,10 @@ function waitForElementsToExist(selector, callback) {
   }, 500);
 }
 
+export const renderMessage = (message) => {
+  alert(message);
+};
+
 export const renderProperties = (inner, g, useTippy) => {
   const disclosureWidget = document.querySelector('#disclosure-widget');
 


### PR DESCRIPTION
Adds two alerts in the following situations:

- Unable to parse JSON data: "There was an error drawing your data. The data must be a valid JSON array of objects."
- Unable to render any nodes or edges: "Your data does not have any information that can be drawn."

Also adds a link in the demo HTML to the data requirements documentation and tweaks the demo CSS slightly to improve spacing.

Closes #70 